### PR TITLE
chore: uninstall deprecated color module

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -6,7 +6,6 @@ module:
   block_content: 0
   breakpoint: 0
   ckeditor: 0
-  color: 0
   components: 0
   config: 0
   contextual: 0


### PR DESCRIPTION
Refs: OPS-8561

Color module is now deprecated.

Should probably revise the versions of the other modules too, but that can be in another ticket.