### PR TITLE
chore: add standard rules for csp config

### DIFF
--- a/config/csp.settings.yml
+++ b/config/csp.settings.yml
@@ -3,20 +3,64 @@ _core:
 report-only:
   enable: true
   directives:
+    connect-src:
+      base: self
+      sources:
+        - www.google-analytics.com
+        - '*.analytics.google.com'
+        - gov-bam.nr-data.net
+    font-src:
+      base: self
+      sources:
+        - 'data:'
+        - fonts.gstatic.com
+    img-src:
+      base: self
+      sources:
+        - 'data:'
+        - www.google-analytics.com
     object-src:
       base: none
     script-src:
       base: self
+      flags:
+        - unsafe-inline
+      sources:
+        - fonts.googleapis.com
+        - www.gstatic.com
+        - www.google.com
+        - www.googletagmanager.com
+        - cdn.jsdelivr.net
+        - js-agent.newrelic.com
+        - gov-bam.nr-data.net
+        - '*.google-analytics.com'
     script-src-attr:
       base: self
     script-src-elem:
       base: self
+      flags:
+        - unsafe-inline
+      sources:
+        - fonts.googleapis.com
+        - www.gstatic.com
+        - www.google.com
+        - www.googletagmanager.com
+        - cdn.jsdelivr.net
+        - js-agent.newrelic.com
+        - gov-bam.nr-data.net
+        - '*.google-analytics.com'
     style-src:
       base: self
+      flags:
+        - unsafe-inline
     style-src-attr:
       base: self
+      flags:
+        - unsafe-inline
     style-src-elem:
       base: self
+      flags:
+        - unsafe-inline
     frame-ancestors:
       base: self
   reporting:


### PR DESCRIPTION
Refs: OPS-8583

This PR based on the branch for https://github.com/UN-OCHA/drupal-starterkit/pull/4 - adds some 'standard' csp config, mainly for google, based on the spreadsheet at: https://docs.google.com/spreadsheets/d/1aJtXMCckhxRSLaMToBS37nwd9XLWeGdtD1rOAbXI7jc/edit?pli=1#gid=0