### PR TITLE
suggestion: adjust restart value to avoid permanent memcache containers

### DIFF
--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -13,7 +13,6 @@ volumes:
 
 services:
   memcache:
-    restart: always
     image: memcached:alpine
     hostname: starterkit-local-memcache
     container_name: starterkit-local-memcache


### PR DESCRIPTION
I noticed the memcache containers for starterkit in my 'docker ps' list when I didn't have starterkit running. I think it might be 'tidier' to remove the 'always restart' directive.