### PR TITLE
chore: bump php version for composer update github workflow

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -17,6 +17,7 @@ jobs:
         patch_branch: 'develop'
         patch_packages: 'drupal/*'
         patch_maintainers: ${{ secrets.DRUPAL_MAINTAINERS }}
+        php_version: '8.1'
         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
         slack_channel_name: ${{ secrets.SLACK_CHANNEL }}
         flowdock_token: ${{ secrets.FLOWDOCK_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -144,9 +144,9 @@ jobs:
         id: dblog
         if: failure()
         uses: cafuego/command-output@main
-          with:
-            run: |
-              docker-compose -f tests/docker-compose.yml exec -T drupal drush watchdog:show
+        with:
+          run: |
+            docker-compose -f tests/docker-compose.yml exec -T drupal drush watchdog:show
 
       - name: Find Comment
         uses: peter-evans/find-comment@v2


### PR DESCRIPTION
Refs: OPS-9186

Looks like this change needs to be merged to main to be taken into account for the workflow action.

![image](https://user-images.githubusercontent.com/67453/227186550-50c448b2-0cad-4c48-8c09-5b5dfcbab8f4.png)

(from https://github.com/UN-OCHA/drupal-starterkit/actions/runs/4497769104/jobs/7917853082 - which fails for the wrong version of php - earlier runs failed because there wasn't a 'develop' branch to check out. )

Follow up tasks include putting the usual protections on the develop branch. A work-around would be to allow the composer-update action to act on the main branch, but for consistency, probably better to include a develop branch in the starterkit.