### PR TITLE
chore: add environment indicator module and config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "drupal/core-dev": "^10",
         "drupal/core-recommended": "^10",
         "drupal/csp": "^1.17",
+        "drupal/environment_indicator": "^4.0",
         "drupal/google_tag": "^1.6",
         "drupal/imageapi_optimize_binaries": "^1.0@beta",
         "drupal/imagemagick": "^3.4",
@@ -89,7 +90,8 @@
             "oomphinc/composer-installers-extender": true,
             "orakili/composer-drupal-info-file-patch-helper": true,
             "phpstan/extension-installer": true,
-            "symfony/flex": true
+            "symfony/flex": true,
+            "drupal-composer/preserve-paths": false
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -90,8 +90,7 @@
             "oomphinc/composer-installers-extender": true,
             "orakili/composer-drupal-info-file-patch-helper": true,
             "phpstan/extension-installer": true,
-            "symfony/flex": true,
-            "drupal-composer/preserve-paths": false
+            "symfony/flex": true
         }
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc443dae2af780a172e72c6d846667a6",
+    "content-hash": "c2a3c91724ee212628d21dac63c9bc44",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3006,6 +3006,54 @@
             "homepage": "https://www.drupal.org/project/entity_reference_revisions",
             "support": {
                 "source": "https://git.drupalcode.org/project/entity_reference_revisions"
+            }
+        },
+        {
+            "name": "drupal/environment_indicator",
+            "version": "4.0.14",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/environment_indicator.git",
+                "reference": "4.0.14"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/environment_indicator-4.0.14.zip",
+                "reference": "4.0.14",
+                "shasum": "ff4fe11fcd5fa08b7ba7a451302cf93e5f68449c"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.0.14",
+                    "datestamp": "1674120945",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "e0ipso",
+                    "homepage": "https://www.drupal.org/user/550110"
+                },
+                {
+                    "name": "mrfelton",
+                    "homepage": "https://www.drupal.org/user/305669"
+                }
+            ],
+            "description": "Adds a color indicator for the different environments.",
+            "homepage": "https://www.drupal.org/project/environment_indicator",
+            "support": {
+                "source": "https://git.drupalcode.org/project/environment_indicator"
             }
         },
         {

--- a/config/config_split.config_split.config_dev.yml
+++ b/config/config_split.config_split.config_dev.yml
@@ -13,6 +13,7 @@ module:
   config_filter: 0
   dblog: 0
   devel: 0
+  environment_indicator_ui: 0
   views_ui: 0
 theme: {  }
 complete_list: {  }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -17,6 +17,7 @@ module:
   dynamic_page_cache: 0
   editor: 0
   entity_reference_revisions: 0
+  environment_indicator: 0
   field: 0
   field_ui: 0
   file: 0

--- a/config/environment_indicator.settings.yml
+++ b/config/environment_indicator.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: Bi0EyyiH6m5wpHRfxlKhqTIhAZayhRQudheDzAcrotU
+toolbar_integration:
+  - toolbar
+favicon: true

--- a/config/environment_indicator.switcher.dev.yml
+++ b/config/environment_indicator.switcher.dev.yml
@@ -1,0 +1,11 @@
+uuid: e9071c1d-8ff4-4639-b786-caf39892a3d5
+langcode: en
+status: true
+dependencies: {  }
+machine: dev
+description: null
+name: Dev
+weight: '0'
+url: ''
+fg_color: '#ffffff'
+bg_color: '#db7b18'

--- a/config/environment_indicator.switcher.prod.yml
+++ b/config/environment_indicator.switcher.prod.yml
@@ -1,0 +1,11 @@
+uuid: adc46858-d138-4b68-ab46-693a12eb5aa2
+langcode: en
+status: false
+dependencies: {  }
+machine: prod
+description: null
+name: Prod
+weight: '10'
+url: ''
+fg_color: '#ffffff'
+bg_color: '#6937ac'

--- a/config/environment_indicator.switcher.stage.yml
+++ b/config/environment_indicator.switcher.stage.yml
@@ -1,0 +1,11 @@
+uuid: 0069b13f-ca13-4c56-850b-3632a219c630
+langcode: en
+status: true
+dependencies: {  }
+machine: stage
+description: null
+name: Stage
+weight: '6'
+url: ''
+fg_color: '#000000'
+bg_color: '#34cc32'

--- a/config_dev/environment_indicator.indicator.yml
+++ b/config_dev/environment_indicator.indicator.yml
@@ -1,0 +1,3 @@
+name: Local
+fg_color: '#ffffff'
+bg_color: '#000000'

--- a/config_dev/environment_indicator.switcher.local.yml
+++ b/config_dev/environment_indicator.switcher.local.yml
@@ -1,0 +1,11 @@
+uuid: 5001f732-adfc-4f57-badb-d74c23813e7f
+langcode: en
+status: true
+dependencies: {  }
+machine: local
+description: null
+name: Local
+weight: ''
+url: 'https://starterkit-local.test'
+fg_color: '#ffffff'
+bg_color: '#000000'


### PR DESCRIPTION
Refs: OPS-8939

Putting in the environment indicator module and 'standard' config (Though it needs ansible config too to work on the dev and prod sites.)