### PR TITLE
chore: adding a valid `on` value to prevent errors on each push

### DIFF
--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -1,6 +1,8 @@
 name: Build docker image
 
 on:
+# Adding to prevent failing builds: `No event triggers defined in `on``
+  workflow_dispatch:
 # Set a correct docker_image variable and then remove the comments from this block to enable automagic builds.
 #  push:
 #    branches:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2.2"
 name: starterkit-test
 
 networks:


### PR DESCRIPTION
Refs: cleanup

We've just started getting failing builds on each push as there's no `on` value in this action. Adding `workflow_dispatch:` to keep it quiet.