### PR TITLE
chore: Use the latest mysql:11 docker image for tests.

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       MEMCACHE_MAX_MEMORY: 64
 
   mysql:
-    image: public.ecr.aws/unocha/mysql:10.11
+    image: public.ecr.aws/unocha/mysql:11
     hostname: starterkit-test-mysql
     container_name: starterkit-test-mysql
     environment:


### PR DESCRIPTION
This is now MariaDB 11.8.6, which matches RDS dev.

Refs: OPS-12081